### PR TITLE
[feat] 簡易検索機能を追加

### DIFF
--- a/src/components/RestrictedItems.jsx
+++ b/src/components/RestrictedItems.jsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, {useState, useEffect} from 'react';
 import PropTypes from 'prop-types';
 import {makeStyles} from '@material-ui/core/styles';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
+import TextField from '@material-ui/core/TextField';
 import {FixedSizeList} from 'react-window';
 import Typography from '@material-ui/core/Typography';
 
@@ -13,6 +14,12 @@ const useStyles = makeStyles((theme) => ({
         maxWidth: 300,
         backgroundColor: theme.palette.background.paper,
     },
+    search: {
+        width: '100%',
+        height: 100,
+        maxWidth: 500,
+        backgroundColor: theme.palette.background.paper,
+    }
 }));
 
 function renderRow(props) {
@@ -33,17 +40,42 @@ renderRow.propTypes = {
 export default function RestrictedItems(props) {
     const classes = useStyles();
     const hitNumbers = props.hitNumbers;
-    const itemCount = (!!hitNumbers) ? hitNumbers.length : 200;
+    const initItemCount = (!!hitNumbers) ? hitNumbers.length : 200;
     const itemSize = 46;
+    const init = true;
     const data = hitNumbers.map(i => {
         return (!!props.data && props.data.length >= i) ? props.data[i-1].name : `No.${i}`;
     });
+
+    const [items, setItems] = useState(data);
+    const [itemCount, setCount] = useState(initItemCount);
+
+    useEffect(() => {
+        if (items.length === 0 || init) {
+            setItems(data);
+            setCount(initItemCount);
+        }
+    }, [props]);
+
+    const filterList = (e) => {
+        const updateList = data.filter((item) => {
+            return item.toLowerCase().search(e.target.value.toLowerCase()) !== -1;
+        })
+        setItems(updateList);
+        const count = (!!updateList) ? updateList.length : 200
+        setCount(count);
+    }
 
     return (
         <div className={classes.root}>
             <Typography variamt="h3" component="h3">封印リスト</Typography>
             <br />
-            <FixedSizeList height={400} width={300} itemSize={itemSize} itemCount={itemCount} itemData={data}>
+            <div>
+                <form className={classes.search} noValidate autoComplete="off">
+                    <TextField id="standard-basic" label="検索キーワード" onChange={filterList}/>
+                </form>
+            </div>
+            <FixedSizeList height={400} width={300} itemSize={itemSize} itemCount={itemCount} itemData={items}>
                 {renderRow}
             </FixedSizeList>
             <br />


### PR DESCRIPTION
### 背景概要
FixedSizeListを使って封印アイテム一覧を表示しているがブラウザの検索機能だと表示されている分しか検索できない。
そこで、全封印アイテムに対して検索可能な検索機能を実装する。

###  変更点
封印アイテム表示コンポーネントに検索機能を実装

### 確認したこと
- デフォルトのビンゴ機能で検索が想定通りに機能すること
- Excelファイルを適用したときに検索が想定通りに機能すること

### 確認してほしいこと
なし

### 確認期限
なし