### PR TITLE
Add browser sheet editor and widen config drawer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "random-bingo",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "random-bingo",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@emotion/react": "^11.9.3",
         "@emotion/styled": "^11.9.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "random-bingo",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "dependencies": {
     "@emotion/react": "^11.9.3",

--- a/src/components/ConfigArea.js
+++ b/src/components/ConfigArea.js
@@ -1,9 +1,10 @@
 import { TextField, Drawer, styled } from "@mui/material";
 import { SaveButton, CloseButton, DownloadButton } from "./Buttons";
 import { UploadForm } from "./ExcelHander";
+import { SheetEditor } from "./SheetEditor";
 
 const CustomDrawer = styled(Drawer)({
-    width: 400
+    width: 720
 })
 
 export const validateMin = (resetMin, setReSettingMinError) => {
@@ -44,6 +45,7 @@ export function ConfigArea(props) {
             variant="persistent"
             anchor="right"
             open={open}
+            PaperProps={{ sx: { width: 720 } }}
         >
             <TextField
                 error={reSettingMinError !== ""}
@@ -73,6 +75,11 @@ export function ConfigArea(props) {
             <DownloadButton
                 data={data}
                 hitNumbers={hitNumbers}
+            />
+            <SheetEditor
+                data={data}
+                hitNumbers={hitNumbers}
+                saveAndRestartConfigArea={saveAndRestartConfigArea}
             />
         </CustomDrawer>
     );

--- a/src/components/SheetEditor.js
+++ b/src/components/SheetEditor.js
@@ -1,0 +1,149 @@
+import { useEffect, useState } from "react";
+import { Box, Button, IconButton, Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, TextField, Typography } from "@mui/material";
+import AddIcon from "@mui/icons-material/Add";
+import DeleteIcon from "@mui/icons-material/Delete";
+
+const columns = ["id", "name", "importance", "rarity", "description"];
+
+const createEmptyRow = (id) => ({
+    id,
+    name: `No:${id}`,
+    importance: "A",
+    rarity: "S",
+    description: `${id}`,
+});
+
+const normalizeRow = (row, index) => ({
+    id: Number(row.id) || index + 1,
+    name: row.name ?? "",
+    importance: row.importance ?? "",
+    rarity: row.rarity ?? "",
+    description: row.description ?? "",
+});
+
+const sortRows = (rows) => rows.slice().sort((a, b) => Number(a.id) - Number(b.id));
+
+export const validateSheetRows = (rows) => {
+    if (rows.length === 0) {
+        window.confirm("[ERROR] 1行以上入力してください。");
+        return false;
+    }
+
+    const ids = new Set();
+    for (const row of rows) {
+        if (!Number.isInteger(Number(row.id)) || Number(row.id) < 0) {
+            window.confirm("[ERROR] idには0以上の整数を入力してください。");
+            return false;
+        }
+        if (ids.has(Number(row.id))) {
+            window.confirm("[ERROR] idが重複しています。");
+            return false;
+        }
+        ids.add(Number(row.id));
+        if (row.importance === "") {
+            window.confirm("[ERROR] すべての行でimportanceを指定してください。");
+            return false;
+        }
+    }
+    return true;
+};
+
+export function SheetEditor(props) {
+    const { data, hitNumbers, saveAndRestartConfigArea } = props;
+    const [rows, setRows] = useState(() => (data ?? []).map(normalizeRow));
+
+    useEffect(() => {
+        setRows((data ?? []).map(normalizeRow));
+    }, [data]);
+
+    const updateCell = (index, key, value) => {
+        setRows((currentRows) => currentRows.map((row, rowIndex) => {
+            if (rowIndex !== index) {
+                return row;
+            }
+            return {
+                ...row,
+                [key]: key === "id" ? Number(value) : value,
+            };
+        }));
+    };
+
+    const addRow = () => {
+        const nextId = rows.length === 0 ? 1 : Math.max(...rows.map((row) => Number(row.id) || 0)) + 1;
+        setRows((currentRows) => [...currentRows, createEmptyRow(nextId)]);
+    };
+
+    const deleteRow = (index) => {
+        setRows((currentRows) => currentRows.filter((_, rowIndex) => rowIndex !== index));
+    };
+
+    const createNewSheet = () => {
+        setRows([createEmptyRow(1), createEmptyRow(2), createEmptyRow(3), createEmptyRow(4), createEmptyRow(5), createEmptyRow(6), createEmptyRow(7), createEmptyRow(8), createEmptyRow(9)]);
+    };
+
+    const saveRows = () => {
+        const normalizedRows = sortRows(rows.map(normalizeRow));
+        if (!validateSheetRows(normalizedRows)) {
+            return;
+        }
+        const availableIds = normalizedRows.map((row) => row.id);
+        const filteredHitNumbers = hitNumbers.filter((hitNumber) => availableIds.includes(hitNumber));
+        saveAndRestartConfigArea(normalizedRows, filteredHitNumbers);
+    };
+
+    return (
+        <Box sx={{ marginTop: "4vh", paddingX: 1 }}>
+            <Typography variant="h6" component="h2">
+                ブラウザでシート編集
+            </Typography>
+            <Typography variant="body2" sx={{ marginBottom: 1 }}>
+                Excelがない場合はここで新規作成・編集して保存できます。
+            </Typography>
+            <Box sx={{ display: "flex", gap: 1, marginBottom: 1 }}>
+                <Button variant="outlined" size="small" onClick={createNewSheet}>
+                    新規作成
+                </Button>
+                <Button variant="outlined" size="small" onClick={addRow} startIcon={<AddIcon />}>
+                    行を追加
+                </Button>
+                <Button variant="contained" size="small" onClick={saveRows}>
+                    編集を保存
+                </Button>
+            </Box>
+            <TableContainer component={Paper} sx={{ maxHeight: 420 }}>
+                <Table stickyHeader size="small">
+                    <TableHead>
+                        <TableRow>
+                            {columns.map((column) => <TableCell key={column}>{column}</TableCell>)}
+                            <TableCell>削除</TableCell>
+                        </TableRow>
+                    </TableHead>
+                    <TableBody>
+                        {rows.map((row, index) => (
+                            <TableRow key={`${row.id}-${index}`}>
+                                {columns.map((column) => (
+                                    <TableCell key={column} sx={{ minWidth: column === "description" ? 180 : 90 }}>
+                                        <TextField
+                                            type={column === "id" ? "number" : "text"}
+                                            value={row[column]}
+                                            onChange={(e) => updateCell(index, column, e.target.value)}
+                                            size="small"
+                                            fullWidth
+                                            multiline={column === "description"}
+                                            inputProps={column === "id" ? { min: 0, step: 1 } : undefined}
+                                        />
+                                    </TableCell>
+                                ))}
+                                <TableCell>
+                                    <IconButton aria-label="delete row" onClick={() => deleteRow(index)}>
+                                        <DeleteIcon />
+                                    </IconButton>
+                                </TableCell>
+                            </TableRow>
+                        ))}
+                    </TableBody>
+                </Table>
+            </TableContainer>
+        </Box>
+    );
+}


### PR DESCRIPTION
### Motivation
- Allow users to create and edit bingo item sheets in the browser when an Excel file is not available so the app can be used without pre-prepared spreadsheets.
- Keep existing upload/download flows while providing an inline editor for convenience and faster iteration.

### Description
- Add a new `SheetEditor` component (`src/components/SheetEditor.js`) that supports creating a new sheet, adding/deleting rows, editing cells, validating rows, and saving to the app state.
- Implement validation in `SheetEditor` to reject empty sheets, non-integer/negative `id`, duplicate `id`, and missing `importance`, and normalize/sort rows before save.
- Integrate the editor into the configuration drawer by importing `SheetEditor` in `src/components/ConfigArea.js` and embedding it, and expand the drawer width to `720` (also set via `PaperProps`).
- Preserve existing behavior by filtering and retaining only hit numbers that still exist in the saved sheet when applying changes via `saveAndRestartConfigArea`.

### Testing
- Ran unit tests with `npm test -- --watchAll=false` and all tests passed.
- Built the production bundle with `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36ae1f6a44832d84425126e43ad653)